### PR TITLE
Fix text overflow

### DIFF
--- a/SceneViewNotification.cs
+++ b/SceneViewNotification.cs
@@ -246,7 +246,7 @@ public class SceneViewNotification : Editor
                 {
                     richText = true,
                     alignment = TextAnchor.MiddleLeft,
-                    wordWrap = true,
+                    wordWrap = false,
                     fontSize = 12,
                     stretchWidth = true,
                     font = (Font)EditorGUIUtility.LoadRequired("Fonts/Lucida Grande.ttf"),
@@ -257,7 +257,8 @@ public class SceneViewNotification : Editor
                         right = 0,
                         top = 0,
                         bottom = 0
-                    }
+                    },
+                    clipping = TextClipping.Overflow
                 };
             }
 


### PR DESCRIPTION
This change fixes the incorrect rendering of the text when the text is too long to fit into the `Rect` lineRect.

Before:
![before](https://user-images.githubusercontent.com/2115149/76294231-c3637f80-62b2-11ea-9932-48ee2c46b0f7.png)

After:
![after](https://user-images.githubusercontent.com/2115149/76294250-cd857e00-62b2-11ea-95a2-15ed8dd96a06.png)

Tested on 2019.3.4f1